### PR TITLE
Replace not-mocked regions with global config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["command-line-utilities"]
 [dependencies]
 clap = { version = "4.5", features = ["derive", "string"] }
 colored = "2.1"
+glob-match = "0.2"
 regex = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "1.0"
 walkdir = "2.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,4 +19,7 @@ pub struct Args {
     #[arg(short, long)]
     #[arg(default_value = get_current_directory().to_os_string())]
     pub directory: PathBuf,
+
+    #[arg(trailing_var_arg = true)]
+    pub files: Vec<PathBuf>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,105 @@
+use glob_match::glob_match;
+use serde::Deserialize;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+const CONFIG_FILENAME: &str = ".jest_lint.json";
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Config {
+    #[serde(default)]
+    pub ignored_modules: Vec<String>,
+}
+
+impl Config {
+    pub fn is_ignored(&self, module: &str) -> bool {
+        self.ignored_modules.iter().any(|pattern| {
+            pattern == module
+                || glob_match(pattern, module)
+                || glob_match(pattern, module.trim_start_matches("./"))
+                || module
+                    .rsplit_once('/')
+                    .is_some_and(|(_, name)| glob_match(pattern, name))
+        })
+    }
+}
+
+pub fn find_config(start: &Path) -> Config {
+    let mut dir = if start.is_file() {
+        start.parent().map(Path::to_path_buf)
+    } else {
+        Some(start.to_path_buf())
+    };
+
+    while let Some(current) = dir {
+        let config_path = current.join(CONFIG_FILENAME);
+        if config_path.exists() {
+            return load_config(&config_path);
+        }
+        dir = current.parent().map(PathBuf::from);
+    }
+
+    Config::default()
+}
+
+fn load_config(path: &Path) -> Config {
+    let contents = fs::read_to_string(path).expect("Error reading config file.");
+    serde_json::from_str(&contents).expect("Error parsing config file.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with(patterns: &[&str]) -> Config {
+        Config {
+            ignored_modules: patterns.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn test_exact_match() {
+        let config = config_with(&["zod"]);
+        assert!(config.is_ignored("zod"));
+        assert!(!config.is_ignored("zod-utils"));
+    }
+
+    #[test]
+    fn test_single_star_matches_one_level() {
+        let config = config_with(&["@mui/*"]);
+        assert!(config.is_ignored("@mui/material"));
+        // Single * should NOT match nested paths
+    }
+
+    #[test]
+    fn test_double_star_matches_nested() {
+        let config = config_with(&["@mui/**"]);
+        assert!(config.is_ignored("@mui/material"));
+        assert!(config.is_ignored("@mui/material/CircularProgress"));
+    }
+
+    #[test]
+    fn test_scss_module_pattern() {
+        let config = config_with(&["*.module.scss"]);
+        assert!(config.is_ignored("./layout.module.scss"));
+        assert!(config.is_ignored("../../app/purchase/page.module.scss"));
+        assert!(!config.is_ignored("./layout.scss"));
+    }
+
+    #[test]
+    fn test_types_pattern() {
+        let config = config_with(&["**/types/*"]);
+        assert!(config.is_ignored("../../types/route"));
+        assert!(config.is_ignored("../../../types/product"));
+    }
+
+    #[test]
+    fn test_next_subpaths() {
+        let config = config_with(&["next/**"]);
+        assert!(config.is_ignored("next/server"));
+        assert!(config.is_ignored("next/font/local"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,17 @@
 use crate::{
     cli::Args,
+    config::{find_config, Config},
     module::Module,
-    test_pair::{find_all_tests_in_directory, TestPair},
+    test_pair::{find_all_tests_in_directory, find_test_pairs_for_files, TestPair},
 };
 use clap::Parser;
 use colored::*;
 use core::slice;
 use regex::Regex;
-use std::{fs, path::Path, sync::LazyLock};
+use std::{fs, path::{Path, PathBuf}, process, sync::LazyLock};
 
 mod cli;
+mod config;
 mod module;
 mod test_pair;
 
@@ -18,80 +20,193 @@ static IMPORT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 });
 static IGNORE_IMPORT_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?s)//#region not-mocked.*?//#endregion").unwrap());
+static IGNORE_COMMENT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"//\s*jest_lint:ignore\s+(.+)").unwrap());
+static JEST_MOCK_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"jest\.mock\("([^"]+)""#).unwrap());
 
 fn main() {
     let args = Args::parse();
 
-    match (args.mocks, args.filename) {
-        (true, Some(path)) => check_file_mock(&path),
-        (true, None) => check_directory_mocks(&args.directory),
-        _ => println!("Oops, no command specified. Try --help."),
+    let has_errors = match (args.mocks, args.filename) {
+        (true, Some(path)) => {
+            let config = find_config(&path);
+            check_file_mock(&path, &config)
+        }
+        (true, None) if !args.files.is_empty() => {
+            let config = find_config(&args.directory);
+            check_files_mocks(&args.files, &config)
+        }
+        (true, None) => {
+            let config = find_config(&args.directory);
+            check_directory_mocks(&args.directory, &config)
+        }
+        _ => {
+            println!("Oops, no command specified. Try --help.");
+            false
+        }
+    };
+
+    if has_errors {
+        process::exit(1);
     }
 }
 
-fn check_file_mock(path: &Path) {
+fn check_file_mock(path: &Path, config: &Config) -> bool {
     match TestPair::try_from(path) {
-        Ok(pair) => check_missing_mocks(slice::from_ref(&pair)),
-        Err(err) => eprintln!("{err}"),
-    };
+        Ok(pair) => check_missing_mocks(slice::from_ref(&pair), config),
+        Err(err) => {
+            eprintln!("{err}");
+            true
+        }
+    }
 }
 
-fn check_directory_mocks(path: &Path) {
-    println!("Looking for files in: {}", path.display());
-    let pairs = find_all_tests_in_directory(path);
+fn check_files_mocks(files: &[PathBuf], config: &Config) -> bool {
+    let pairs = find_test_pairs_for_files(files);
     if pairs.is_empty() {
-        println!("Could not find test file pairs");
-        return;
+        println!("No test file pairs found for the given files.");
+        return false;
     }
 
     print_under_test(&pairs);
     println!("Checking that all imports have a mock.");
-    check_missing_mocks(&pairs);
+    check_missing_mocks(&pairs, config)
 }
 
-fn check_missing_mocks(pairs: &[TestPair]) {
+fn check_directory_mocks(path: &Path, config: &Config) -> bool {
+    println!("Looking for files in: {}", path.display());
+    let pairs = find_all_tests_in_directory(path);
+    if pairs.is_empty() {
+        println!("Could not find test file pairs");
+        return false;
+    }
+
+    print_under_test(&pairs);
+    println!("Checking that all imports have a mock.");
+    check_missing_mocks(&pairs, config)
+}
+
+fn check_missing_mocks(pairs: &[TestPair], config: &Config) -> bool {
+    let mut has_errors = false;
     for pair in pairs {
         println!("Checking {}... ", pair.module_file.display());
-        let imports = get_imports_from_file(&pair.module_file);
+        let all_imports = get_all_imports_from_file(&pair.module_file);
+        let imports: Vec<&Module> = all_imports
+            .iter()
+            .filter(|module| !config.is_ignored(module.name()))
+            .collect();
 
         if imports.is_empty() {
             println!("  No imports.");
+            check_test_for_warnings(pair, &all_imports, config);
             continue;
         }
 
         print_imports(&imports);
-        check_test_for_jest_mocks(pair, &imports);
+        if check_test_for_jest_mocks(pair, &imports, &all_imports, config) {
+            has_errors = true;
+        }
     }
+    has_errors
 }
 
-fn check_test_for_jest_mocks(pair: &TestPair, modules: &[Module]) {
+fn check_test_for_jest_mocks(
+    pair: &TestPair,
+    modules: &[&Module],
+    all_imports: &[Module],
+    config: &Config,
+) -> bool {
     let test_contents = fs::read_to_string(&pair.test_file).unwrap();
-    let missing_mocks: Vec<&Module> = modules
+    let test_ignores = get_test_ignores(&test_contents);
+    let test_mocks = get_test_mocks(&test_contents);
+
+    let missing_mocks: Vec<&&Module> = modules
         .iter()
-        .filter(|module| !module.mock_with_in(&test_contents))
+        .filter(|module| !module.mock_with_in(&test_contents) && !module.in_list(&test_ignores))
         .collect();
 
-    if missing_mocks.is_empty() {
-        println!(
-            "\n{} All your imports are mocked.\n",
-            "Good job!".green().bold()
-        );
-    } else {
+    let has_missing = !missing_mocks.is_empty();
+    if has_missing {
         println!("{}", "  Missing mocks:".red());
         for module in missing_mocks {
             println!("    {}", module.mock());
         }
     }
+
+    let warnings = get_warnings(&test_mocks, all_imports, config);
+    let has_warnings = !warnings.is_empty();
+    if has_warnings {
+        println!("{}", "  Warnings:".yellow());
+        for warning in &warnings {
+            println!("    {warning}");
+        }
+    }
+
+    if !has_missing && !has_warnings {
+        println!(
+            "\n{} All your imports are mocked.\n",
+            "Good job!".green().bold()
+        );
+    }
+
+    has_missing
 }
 
-fn print_imports(modules: &[Module]) {
+fn check_test_for_warnings(pair: &TestPair, all_imports: &[Module], config: &Config) {
+    let test_contents = fs::read_to_string(&pair.test_file).unwrap();
+    let test_mocks = get_test_mocks(&test_contents);
+    let warnings = get_warnings(&test_mocks, all_imports, config);
+    if !warnings.is_empty() {
+        println!("{}", "  Warnings:".yellow());
+        for warning in &warnings {
+            println!("    {warning}");
+        }
+    }
+}
+
+fn get_warnings(test_mocks: &[String], all_imports: &[Module], config: &Config) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    for mock in test_mocks {
+        if config.is_ignored(mock) {
+            warnings.push(format!(
+                "jest.mock(\"{mock}\") is unnecessary (module is globally ignored)"
+            ));
+        } else if !all_imports.iter().any(|import| import.name() == mock) {
+            warnings.push(format!(
+                "jest.mock(\"{mock}\") does not match any import in the module under test"
+            ));
+        }
+    }
+
+    warnings
+}
+
+fn get_test_mocks(test_contents: &str) -> Vec<String> {
+    JEST_MOCK_REGEX
+        .captures_iter(test_contents)
+        .filter_map(|capture| capture.get(1))
+        .map(|m| m.as_str().to_string())
+        .collect()
+}
+
+fn get_test_ignores(test_contents: &str) -> Vec<String> {
+    IGNORE_COMMENT_REGEX
+        .captures_iter(test_contents)
+        .filter_map(|capture| capture.get(1))
+        .flat_map(|m| m.as_str().split(',').map(|s| s.trim().to_string()))
+        .collect()
+}
+
+fn print_imports(modules: &[&Module]) {
     println!("  Imports:");
     for module in modules {
         println!("    {module}");
     }
 }
 
-fn get_imports_from_file(path: &Path) -> Vec<Module> {
+fn get_all_imports_from_file(path: &Path) -> Vec<Module> {
     let contents = fs::read_to_string(path).expect("Error reading file.");
     let filtered_contents = IGNORE_IMPORT_REGEX.replace_all(&contents, "");
     IMPORT_REGEX

--- a/src/module.rs
+++ b/src/module.rs
@@ -8,9 +8,17 @@ impl Module {
         Self(module.to_string())
     }
 
+    pub fn name(&self) -> &str {
+        &self.0
+    }
+
     pub fn mock_with_in(&self, test_file: &str) -> bool {
         let mock = format!(r#"jest.mock("{}""#, self.0);
         test_file.contains(&mock)
+    }
+
+    pub fn in_list(&self, modules: &[String]) -> bool {
+        modules.iter().any(|m| m == &self.0)
     }
 
     pub fn mock(&self) -> String {

--- a/src/test_pair.rs
+++ b/src/test_pair.rs
@@ -92,3 +92,32 @@ pub fn find_all_tests_in_directory(path: impl AsRef<Path>) -> Vec<TestPair> {
         .flat_map(TestPair::try_from)
         .collect()
 }
+
+pub fn find_test_pairs_for_files(files: &[PathBuf]) -> Vec<TestPair> {
+    let mut pairs = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for path in files {
+        if let Ok(pair) = TestPair::try_from(path.as_path()) {
+            if seen.insert(pair.test_file.clone()) {
+                pairs.push(pair);
+            }
+            continue;
+        }
+
+        let name = path.file_name().unwrap_or_default().to_str().unwrap_or("");
+        for ext in [SPEC_FILE_EXT, TEST_FILE_EXT] {
+            if let Some((base, file_ext)) = name.rsplit_once('.') {
+                let spec_name = format!("{base}{ext}.{file_ext}");
+                let spec_path = path.with_file_name(spec_name);
+                if let Ok(pair) = TestPair::try_from(spec_path.as_path()) {
+                    if seen.insert(pair.test_file.clone()) {
+                        pairs.push(pair);
+                    }
+                }
+            }
+        }
+    }
+
+    pairs
+}


### PR DESCRIPTION
jest_lint required every source file to wrap imports in `//#region not-mocked` blocks to exclude them from mock checking. This leaked test concerns into production code and was almost always the same set of modules (next/server, zod, @prisma/client, etc.) repeated across 60+ files.

- Add `.jest_lint.json` config file with `ignoredModules` list and glob pattern support, searched upward from the target file
- Add `// jest_lint:ignore` comments in spec files for per-file exceptions
- Accept file paths as positional args so CI can pass in changed files directly
- Warn when a test mocks a globally ignored module or a module not imported by the code under test
- Exit non-zero when missing mocks are found
